### PR TITLE
Adding information about server address and port.

### DIFF
--- a/src/services/gnmi_service.py
+++ b/src/services/gnmi_service.py
@@ -503,7 +503,11 @@ class Subscribe(grpc_lib.Rpc):
         self.streamer.send(response)
 
     def stream(self, ip = None, port = None, protocol = None, formatting=None):
-        self.streamer = NotificationStreamer(ip=ip, port=port, protocol=protocol, formatting=formatting)
+        self.streamer = NotificationStreamer(ip=ip, port=port,
+                                             server_addr=self.server_addr,
+                                             server_port=self.server_port,
+                                             protocol=protocol,
+                                             formatting=formatting)
         
 
 class NotificationStreamer(object):
@@ -513,10 +517,13 @@ class NotificationStreamer(object):
         destination
     '''
     def __init__(self, ip=None, port=None, protocol=None,
+                 server_addr=None, server_port=None,
                  formatting='json'):
         self.ip = ip
         self.port = port
         self.protocol = protocol
+        self.server_addr = server_addr
+        self.server_port = server_port
         self.formatting = formatting
         if protocol == 'udp':
             self.socket = self.udp_socket()
@@ -562,6 +569,8 @@ class NotificationStreamer(object):
                         context = context[el.name]
 
                 output_msg = {}
+                output_msg['address'] = self.server_addr
+                output_msg['port'] = self.server_port
                 output_msg['notification'] = notification
                 output_msg['timestamp'] = msg.update.timestamp
                 output_msg['update_type'] = update_type

--- a/src/services/grpc_lib.py
+++ b/src/services/grpc_lib.py
@@ -208,6 +208,7 @@ class Rpc:
 
     def __init__(self, stub=None, name=None, rpc_type=None,
                  metadata=None, delimiter=None, timeout=None,
+                 server_addr=None, server_port=None,
                  *args, **kwargs):
         self.stub = stub
         self.rpc_type = rpc_type
@@ -229,6 +230,10 @@ class Rpc:
 
         self.request_handler = None #gnmi.SetRequest
         self.response_handler = None #gnmi.SetResponse
+
+        self.server_addr = server_addr
+        self.server_port = server_port
+
 
     def __str__(self):
         raise NotImplementedError

--- a/src/shell/grpc_shell.py
+++ b/src/shell/grpc_shell.py
@@ -645,17 +645,17 @@ def gnmi_subscribe(ctx, name, paging, mode, qos, prefix, allow_aggregation, use_
                         click.echo(ctx.obj['manager'].get_rpc(type=rpc_type, name=name))
             else:
                 click.secho('Rpc with name \'{name}\' doesnt exists, adding one to rpc manager'.format(name=name), fg='yellow')
-                ctx.obj['manager'].rpcs[rpc_type][name] = gnmi.Subscribe(
-                                                                        stub=ctx.obj['gnmi_stub'],
-                                                                        metadata=ctx.obj['context'].metadata,
-                                                                        name=name,
-                                                                        mode=mode,
-                                                                        prefix=prefix,
-                                                                        delimiter=default_delimiter,
-                                                                        qos=qos,
-                                                                        allow_aggregation=allow_aggregation,
-                                                                        use_aliases=use_aliases
-                                                         )
+                ctx.obj['manager'].rpcs[rpc_type][name] = gnmi.Subscribe(stub=ctx.obj['gnmi_stub'],
+                                                                         metadata=ctx.obj['context'].metadata,
+                                                                         server_addr=ctx.obj['context'].ip,
+                                                                         server_port=ctx.obj['context'].port,
+                                                                         name=name,
+                                                                         mode=mode,
+                                                                         prefix=prefix,
+                                                                         delimiter=default_delimiter,
+                                                                         qos=qos,
+                                                                         allow_aggregation=allow_aggregation,
+                                                                         use_aliases=use_aliases)
             ctx.obj['RPC_NAME'] = name
             ctx.obj['RPC_TYPE'] = rpc_type
         except KeyError as e:


### PR DESCRIPTION
These are quite beneficial when forwarding the data to other processors but
should be normally decoupled from RPC layer, so for now its optional and used
only for subscribe rpc and its stream forwarder.